### PR TITLE
Add missing "msg" argument

### DIFF
--- a/profiles.py
+++ b/profiles.py
@@ -65,7 +65,7 @@ class Profiles(BotPlugin):
             return (msg, cmd, args)
 
         if not dry_run and not self.bot_config.HIDE_RESTRICTED_ACCESS:
-            self._bot.send_simple_reply("You're not allowed to access this command")
+            self._bot.send_simple_reply(msg, "You're not allowed to access this command")
 
         return BLOCK_COMMAND
 


### PR DESCRIPTION
There is an error due to missing `msg` argument
```
2019-09-23 03:10:25,987 ERROR    errbot.core               Exception in a filter command, blocking the command in doubt
Traceback (most recent call last):
  File "/opt/pyenvs/bot/lib/python3.7/site-packages/errbot/core.py", line 343, in _process_command_filters
    msg, cmd, args = cmd_filter(msg, cmd, args, dry_run)
  File "/home/abruno/projects/bot/data/plugins/shengis/err-profiles/profiles.py", line 68, in acls
    self._bot.send_simple_reply("You're not allowed to access this command")
TypeError: send_simple_reply() missing 1 required positional argument: 'text'
```

Fixed by just adding the `msg` argument